### PR TITLE
🚑️ Sqlnode 경로 RDB테이블(postgreSQL)설정

### DIFF
--- a/graph/nodes/sql_search_node.py
+++ b/graph/nodes/sql_search_node.py
@@ -17,119 +17,114 @@ SQL Search Node
 """
 """
 sql_search_node.py
-- eval에서 검증된 키워드/엔티티를 기반으로 RDB(PostgreSQL) 추가 검색
-- 결과는 state['verified_chunks']에 보강(merge) 또는 state['sql_results']에 별도 저장
-- DB 환경변수:
-  - DATABASE_URL (예: postgresql+psycopg://user:pass@host:port/db)
-  또는
-  - PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE
+- verified_chunks의 related_chunk_id를 사용하여 PostgreSQL에서 관련 이미지 검색
+- image_metadata 테이블에서 이미지 메타데이터 조회
 """
 
 import os
 from typing import Dict, Any, List
 
-# psycopg (3.x)
 try:
-    import psycopg
-except Exception:
-    psycopg = None  # 설치 안 되어도 소프트 실패
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+except ImportError:
+    psycopg2 = None
 
-TABLE = os.getenv("SQL_CHUNK_TABLE", "kb_chunks")  # 예: 텍스트 테이블명
-TEXT_COL = os.getenv("SQL_TEXT_COL", "content")
-META_COL = os.getenv("SQL_META_COL", "metadata")
 
-def _connect():
-    # DATABASE_URL 우선
-    dsn = os.getenv("DATABASE_URL")
-    if dsn:
-        return psycopg.connect(dsn) if psycopg else None
-    # 개별 변수
-    if psycopg:
-        return psycopg.connect(
-            host=os.getenv("PGHOST", "localhost"),
-            port=int(os.getenv("PGPORT", "5432")),
-            user=os.getenv("PGUSER"),
-            password=os.getenv("PGPASSWORD"),
-            dbname=os.getenv("PGDATABASE"),
+def _get_db_connection():
+    """PostgreSQL 연결"""
+    if not psycopg2:
+        return None
+    
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("PG_HOST", "localhost"),
+            port=int(os.getenv("PG_PORT", "5432")),
+            user=os.getenv("PG_USER"),
+            password=os.getenv("PG_PASSWORD"),
+            dbname=os.getenv("PG_DB")
         )
-    return None
+        return conn
+    except Exception as e:
+        print(f"DB 연결 실패: {e}")
+        return None
 
-def _extract_keywords(state: Dict[str, Any]) -> List[str]:
-    """
-    verified_chunks에서 핵심 키워드 후보 추출.
-    프로젝트 상황에 맞게 개선하세요.
-    """
-    kws = []
-    for ch in (state.get("verified_chunks") or []):
-        # 예: chunk에 'keywords' 리스트나 'title'/'summary' 존재한다고 가정
-        if isinstance(ch, dict):
-            if "keywords" in ch and isinstance(ch["keywords"], list):
-                kws.extend([str(k) for k in ch["keywords"] if k])
-            if "title" in ch:
-                kws.append(str(ch["title"]))
-    # 중복 제거/정리
-    seen, uniq = set(), []
-    for k in kws:
-        kk = k.strip()
-        if kk and kk.lower() not in seen:
-            seen.add(kk.lower())
-            uniq.append(kk)
-    return uniq[:10]  # 안전하게 제한
 
-def _search_sql(cur, keywords: List[str], limit: int = 8) -> List[Dict[str, Any]]:
-    """
-    단순 ILIKE OR 매칭(예시).
-    실제로는 tsvector/GIN, re-rank, 점수 컬럼 등을 쓰는 게 좋음.
-    """
-    if not keywords:
+def _extract_chunk_ids(state: Dict[str, Any]) -> List[str]:
+    """verified_chunks에서 chunk_id 추출"""
+    chunk_ids = []
+    for chunk in (state.get("verified_chunks") or []):
+        if isinstance(chunk, dict):
+            chunk_id = chunk.get("chunk_id") or chunk.get("id")
+            if chunk_id:
+                chunk_ids.append(str(chunk_id))
+    return chunk_ids
+
+
+def _search_images_from_db(conn, chunk_ids: List[str]) -> List[Dict[str, Any]]:
+    """PostgreSQL에서 chunk_id와 매칭되는 이미지 검색"""
+    if not chunk_ids:
         return []
-    conditions = " OR ".join([f"{TEXT_COL} ILIKE %s" for _ in keywords])
-    sql = f"""
-        SELECT {TEXT_COL} AS content, {META_COL} AS metadata
-        FROM {TABLE}
-        WHERE {conditions}
-        LIMIT {limit}
-    """
-    params = [f"%{k}%" for k in keywords]
-    cur.execute(sql, params)
-    rows = cur.fetchall()
-    results = []
-    for r in rows:
-        content = r[0]
-        meta = r[1] if len(r) > 1 else None
-        results.append({"content": content, "metadata": meta})
-    return results
+    
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            # IN 절을 사용한 쿼리
+            placeholders = ','.join(['%s'] * len(chunk_ids))
+            query = f"""
+                SELECT 
+                    image_id,
+                    image_url,
+                    disease_name,
+                    category,
+                    image_type,
+                    alt_text,
+                    caption,
+                    table_context,
+                    related_chunk_id
+                FROM image_metadata
+                WHERE related_chunk_id IN ({placeholders})
+            """
+            cur.execute(query, chunk_ids)
+            rows = cur.fetchall()
+            
+            # RealDictCursor는 dict 형태로 반환
+            return [dict(row) for row in rows]
+    except Exception as e:
+        print(f"이미지 검색 실패: {e}")
+        return []
+
 
 def sql_search_node(state: Dict[str, Any]) -> Dict[str, Any]:
     """
     Input:
-      - state['verified_chunks']: List[Dict] (eval에서 검증된 근거)
+      - state['verified_chunks']: List[Dict] (eval에서 검증된 chunk)
     Output:
-      - state['sql_results']: List[Dict] (SQL 보강 결과)
-      - (선택) state['verified_chunks']에 append 병합
+      - state['related_images']: List[Dict] (관련 이미지 메타데이터)
     """
-    keywords = _extract_keywords(state)
-    if not psycopg:
-        # DB 드라이버 없으면 소프트 실패
-        state["sql_results"] = []
-        state["sql_error"] = "psycopg not installed"
+    if not psycopg2:
+        state["related_images"] = []
+        state["sql_error"] = "psycopg2 not installed"
         return state
-
+    
+    # chunk_id 추출
+    chunk_ids = _extract_chunk_ids(state)
+    
+    if not chunk_ids:
+        state["related_images"] = []
+        return state
+    
+    # DB 연결
+    conn = _get_db_connection()
+    if not conn:
+        state["related_images"] = []
+        state["sql_error"] = "DB connection failed"
+        return state
+    
     try:
-        conn = _connect()
-        if conn is None:
-            state["sql_results"] = []
-            state["sql_error"] = "DB connection failed"
-            return state
-        with conn, conn.cursor() as cur:
-            results = _search_sql(cur, keywords)
-    except Exception as e:
-        state["sql_results"] = []
-        state["sql_error"] = f"sql_search error: {e}"
-        return state
-
-    # 보강: verified_chunks 뒤에 붙이거나 별도 키로 전달
-    state["sql_results"] = results
-    # 선택적으로 병합하려면 아래 주석 해제
-    # state["verified_chunks"] = (state.get("verified_chunks") or []) + results
+        # 이미지 검색
+        related_images = _search_images_from_db(conn, chunk_ids)
+        state["related_images"] = related_images
+    finally:
+        conn.close()
+    
     return state


### PR DESCRIPTION
services/etl/loader/load_rdb.py로 services/etl/loader/schemas.sql 쿼리문 실행하면 생성되는 RDB테이블을 sqlnode에서 사용하도록 설정.

->현재수정PR

DJango 시스템(config/setting.py)에서 env를 로드하여 LangGraph 노드와 에이전트에서 사용하는 AImodel들이 env를 사용할 수 있도록 구현함

sql_search, classify, chat_llm 3개의 노드와 classify agent  또한 gitignore  의 복잡한 주석과 필요없는부분들 정리

->이전수정PR
