### PR TITLE
Feature/node/taeho

### DIFF
--- a/graph/nodes/chat_llm_node.py
+++ b/graph/nodes/chat_llm_node.py
@@ -65,6 +65,7 @@ def chat_llm_node(state: Dict[str, Any]) -> Dict[str, Any]:
       - state['sql_results']: List[Dict]
       - state['counseling_context']: str
       - state['user_question']: str
+      - state['node_type']: str (classify 결과: "counseling" 또는 "information")
     Output:
       - state['final_answer']: str
     """
@@ -72,17 +73,34 @@ def chat_llm_node(state: Dict[str, Any]) -> Dict[str, Any]:
     ctx = (state.get("counseling_context") or "").strip()
     verified = state.get("verified_chunks") or []
     sql_res = state.get("sql_results") or []
+    node_type = (state.get("node_type") or "").strip().lower()
 
     # 근거 텍스트 정리(정보형)
     evidence = verified + sql_res
     evidence_text = _shorten_chunks(evidence)
 
-    system = (
-        "너는 한국어 전문상담가이다. 공감적이고 명료하게 답하되, "
-        "정보형 질문에는 근거를 간략히 요약하고, 상담형(콘텍스트 있을 때)에는 "
-        "안전하고 현실적인 다음 행동을 제안한다. 의학적 진단/처방은 하지 않는다. "
-        "마지막에 후속 질문 1개를 제시한다."
-    )
+    # node_type에 따라 시스템 프롬프트 분기
+    if node_type == "counseling":
+        system = (
+            "당신은 따뜻하고 자상하며 배려심 깊은 전문 심리상담가이자 정신과 의사입니다. "
+            "사용자의 감정과 상황을 깊이 공감하며, 부드럽고 이해심 있는 어조로 대화합니다.\n\n"
+            "답변 시 다음을 준수하세요:\n"
+            "1. 사용자의 감정을 먼저 인정하고 공감을 표현하세요\n"
+            "2. 전문적이면서도 따뜻한 톤으로 조언을 제공하세요\n"
+            "3. 의학적 조언이나 증상에 대한 설명을 제공할 수 있지만, 반드시 답변 마지막에 다음 문구를 포함하세요:\n"
+            "   '※ 본 답변은 참고 사항일 뿐이며, 정식 의학적 진단이나 처방이 아닙니다. "
+            "정확한 진단과 치료를 위해서는 반드시 전문의와 상담하시기 바랍니다.'\n"
+            "4. 안전하고 현실적인 다음 행동을 제안하세요\n"
+            "5. 사용자가 더 편안하게 이야기할 수 있도록 부드러운 후속 질문 1개를 제시하세요\n"
+            "6. 절대 판단하거나 비난하지 말고, 항상 지지적인 태도를 유지하세요"
+        )
+    else:
+        system = (
+            "너는 한국어 전문상담가이다. 공감적이고 명료하게 답하되, "
+            "정보형 질문에는 근거를 간략히 요약하고, 상담형(콘텍스트 있을 때)에는 "
+            "안전하고 현실적인 다음 행동을 제안한다. 의학적 진단/처방은 하지 않는다. "
+            "마지막에 후속 질문 1개를 제시한다."
+        )
 
     # 프롬프트 구성
     parts = []

--- a/graph/nodes/classify_node.py
+++ b/graph/nodes/classify_node.py
@@ -36,66 +36,65 @@ Classify Node
 """
 classify_node.py
 - 사용자 질문(user_question)을 {information, counseling, unknown} 으로 분류
-- 1차: 규칙 기반 키워드/패턴
-- 2차(애매할 때만): LLM(gpt-5-nano)로 보정
+- gpt-5-nano를 사용하여 모든 질문을 분류
 """
 
-import re
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 # ▼ OpenAI SDK 사용 (프로젝트 래퍼가 있으면 교체하세요)
 try:
     from openai import OpenAI
     _client = OpenAI()  # 환경변수 OPENAI_API_KEY 필요
-except Exception:  # SDK 미설치/키 미설정 시에도 코드 동작(LLM 미사용 분류만)
+except Exception:  # SDK 미설치/키 미설정 시에도 코드 동작
     _client = None
 
 
-INFO_HINTS = [
-    r"정신질환[이|에]\s*대해", r"증상\s*종류", r"치료\s*방법", r"진단\s*기준",
-    r"우울증|불안장애|조현병|ADHD|PTSD|공황장애|강박장애|양극성", r"약물|부작용|심리 교육|인지행동"
-]
-COUNSEL_HINTS = [
-    r"저는|제가|내가|나", r"최근\s*\d+일|요즘|최근에", r"잠이\s*안|수면\s*문제|밥맛|식사\s*문제",
-    r"불안해|우울해|죽고|자해|극단|무기력|멘탈|감정", r"상담|도움|조언|어떻게\s*해야"
-]
-
-def _regex_any(patterns, text) -> bool:
-    return any(re.search(p, text, re.I) for p in patterns)
-
-def _rule_based_classify(q: str) -> Optional[str]:
-    q = q.strip()
-    if not q:
-        return "unknown"
-    if _regex_any(COUNSEL_HINTS, q):
-        return "counseling"
-    if _regex_any(INFO_HINTS, q):
-        return "information"
-    return None  # 애매 → LLM 보정 시도
-
-def _llm_refine(q: str) -> str:
-    """gpt-5-nano로 보정. 실패 시 'unknown'."""
+def _classify_with_llm(q: str) -> str:
+    """
+    gpt-5-nano를 사용하여 질문을 세 가지 레이블로 분류
+    - information: 정신질환 지식/치료/진단기준 등의 정보만 물어보는 경우
+    - counseling: 개인 상태/감정/증상 이야기와 상담 관련 내용이 조금이라도 포함된 경우
+    - unknown: 서비스와 관계없는 질문 (예: "오늘 밥 뭐먹을까?")
+    """
     if _client is None:
         return "unknown"
+    
     system = (
-        "너는 질문을 세 가지 레이블 중 하나로만 분류한다: "
-        "'information', 'counseling', 'unknown'. "
-        "정신질환 지식/치료/진단 기준 등은 information, "
-        "개인 상태/감정/증상 이야기와 상담은 counseling, "
-        "그 외는 unknown. 정답만 한 단어로 출력."
+        "당신은 사용자 질문을 세 가지 레이블 중 하나로 정확하게 분류하는 전문가입니다.\n\n"
+        "분류 기준:\n"
+        "1. 'information': 정신질환에 대한 지식, 치료 방법, 진단 기준 등 객관적인 정보만을 요청하는 질문\n"
+        "   예시: '우울증이란 무엇인가요?', '불안장애의 증상은?', 'ADHD 치료 방법은?'\n\n"
+        "2. 'counseling': 개인의 상태, 감정, 증상에 대한 이야기나 상담 관련 내용이 조금이라도 포함된 질문\n"
+        "   예시: '요즘 우울한데 어떻게 해야 하나요?', '제가 불안장애인가요?', '잠을 못 자요'\n"
+        "   주의: 개인적 경험이나 감정이 조금이라도 언급되면 counseling으로 분류\n\n"
+        "3. 'unknown': 정신건강 서비스와 전혀 관계없는 질문\n"
+        "   예시: '오늘 밥 뭐먹을까?', '날씨 어때?', '맛집 추천해줘', '파이썬 코드 작성해줘'\n\n"
+        "반드시 'information', 'counseling', 'unknown' 중 하나만 정확히 출력하세요. 다른 설명은 하지 마세요."
     )
+    
     user = f"질문: {q}"
+    
     try:
         resp = _client.chat.completions.create(
             model="gpt-5-nano",
-            messages=[{"role": "system", "content": system},
-                      {"role": "user", "content": user}],
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user}
+            ],
             temperature=0
         )
         label = resp.choices[0].message.content.strip().lower()
-        return label if label in {"information","counseling","unknown"} else "unknown"
-    except Exception:
+        
+        # 유효한 레이블인지 확인
+        if label in {"information", "counseling", "unknown"}:
+            return label
+        else:
+            return "unknown"
+            
+    except Exception as e:
+        print(f"LLM 분류 중 오류 발생: {e}")
         return "unknown"
+
 
 def classify_node(state: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -105,8 +104,14 @@ def classify_node(state: Dict[str, Any]) -> Dict[str, Any]:
       - state['question_type']: 'information' | 'counseling' | 'unknown'
     """
     q = (state.get("user_question") or "").strip()
-    label = _rule_based_classify(q)
-    if label is None:
-        label = _llm_refine(q)
-    state["question_type"] = label or "unknown"
+    
+    # 빈 질문은 unknown으로 처리
+    if not q:
+        state["question_type"] = "unknown"
+        return state
+    
+    # gpt-5-nano로 분류
+    label = _classify_with_llm(q)
+    state["question_type"] = label
+    
     return state

--- a/graph/nodes/sql_search_node.py
+++ b/graph/nodes/sql_search_node.py
@@ -17,119 +17,114 @@ SQL Search Node
 """
 """
 sql_search_node.py
-- eval에서 검증된 키워드/엔티티를 기반으로 RDB(PostgreSQL) 추가 검색
-- 결과는 state['verified_chunks']에 보강(merge) 또는 state['sql_results']에 별도 저장
-- DB 환경변수:
-  - DATABASE_URL (예: postgresql+psycopg://user:pass@host:port/db)
-  또는
-  - PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE
+- verified_chunks의 related_chunk_id를 사용하여 PostgreSQL에서 관련 이미지 검색
+- image_metadata 테이블에서 이미지 메타데이터 조회
 """
 
 import os
 from typing import Dict, Any, List
 
-# psycopg (3.x)
 try:
-    import psycopg
-except Exception:
-    psycopg = None  # 설치 안 되어도 소프트 실패
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+except ImportError:
+    psycopg2 = None
 
-TABLE = os.getenv("SQL_CHUNK_TABLE", "kb_chunks")  # 예: 텍스트 테이블명
-TEXT_COL = os.getenv("SQL_TEXT_COL", "content")
-META_COL = os.getenv("SQL_META_COL", "metadata")
 
-def _connect():
-    # DATABASE_URL 우선
-    dsn = os.getenv("DATABASE_URL")
-    if dsn:
-        return psycopg.connect(dsn) if psycopg else None
-    # 개별 변수
-    if psycopg:
-        return psycopg.connect(
-            host=os.getenv("PGHOST", "localhost"),
-            port=int(os.getenv("PGPORT", "5432")),
-            user=os.getenv("PGUSER"),
-            password=os.getenv("PGPASSWORD"),
-            dbname=os.getenv("PGDATABASE"),
+def _get_db_connection():
+    """PostgreSQL 연결"""
+    if not psycopg2:
+        return None
+    
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("PG_HOST", "localhost"),
+            port=int(os.getenv("PG_PORT", "5432")),
+            user=os.getenv("PG_USER"),
+            password=os.getenv("PG_PASSWORD"),
+            dbname=os.getenv("PG_DB")
         )
-    return None
+        return conn
+    except Exception as e:
+        print(f"DB 연결 실패: {e}")
+        return None
 
-def _extract_keywords(state: Dict[str, Any]) -> List[str]:
-    """
-    verified_chunks에서 핵심 키워드 후보 추출.
-    프로젝트 상황에 맞게 개선하세요.
-    """
-    kws = []
-    for ch in (state.get("verified_chunks") or []):
-        # 예: chunk에 'keywords' 리스트나 'title'/'summary' 존재한다고 가정
-        if isinstance(ch, dict):
-            if "keywords" in ch and isinstance(ch["keywords"], list):
-                kws.extend([str(k) for k in ch["keywords"] if k])
-            if "title" in ch:
-                kws.append(str(ch["title"]))
-    # 중복 제거/정리
-    seen, uniq = set(), []
-    for k in kws:
-        kk = k.strip()
-        if kk and kk.lower() not in seen:
-            seen.add(kk.lower())
-            uniq.append(kk)
-    return uniq[:10]  # 안전하게 제한
 
-def _search_sql(cur, keywords: List[str], limit: int = 8) -> List[Dict[str, Any]]:
-    """
-    단순 ILIKE OR 매칭(예시).
-    실제로는 tsvector/GIN, re-rank, 점수 컬럼 등을 쓰는 게 좋음.
-    """
-    if not keywords:
+def _extract_chunk_ids(state: Dict[str, Any]) -> List[str]:
+    """verified_chunks에서 chunk_id 추출"""
+    chunk_ids = []
+    for chunk in (state.get("verified_chunks") or []):
+        if isinstance(chunk, dict):
+            chunk_id = chunk.get("chunk_id") or chunk.get("id")
+            if chunk_id:
+                chunk_ids.append(str(chunk_id))
+    return chunk_ids
+
+
+def _search_images_from_db(conn, chunk_ids: List[str]) -> List[Dict[str, Any]]:
+    """PostgreSQL에서 chunk_id와 매칭되는 이미지 검색"""
+    if not chunk_ids:
         return []
-    conditions = " OR ".join([f"{TEXT_COL} ILIKE %s" for _ in keywords])
-    sql = f"""
-        SELECT {TEXT_COL} AS content, {META_COL} AS metadata
-        FROM {TABLE}
-        WHERE {conditions}
-        LIMIT {limit}
-    """
-    params = [f"%{k}%" for k in keywords]
-    cur.execute(sql, params)
-    rows = cur.fetchall()
-    results = []
-    for r in rows:
-        content = r[0]
-        meta = r[1] if len(r) > 1 else None
-        results.append({"content": content, "metadata": meta})
-    return results
+    
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            # IN 절을 사용한 쿼리
+            placeholders = ','.join(['%s'] * len(chunk_ids))
+            query = f"""
+                SELECT 
+                    image_id,
+                    image_url,
+                    disease_name,
+                    category,
+                    image_type,
+                    alt_text,
+                    caption,
+                    table_context,
+                    related_chunk_id
+                FROM image_metadata
+                WHERE related_chunk_id IN ({placeholders})
+            """
+            cur.execute(query, chunk_ids)
+            rows = cur.fetchall()
+            
+            # RealDictCursor는 dict 형태로 반환
+            return [dict(row) for row in rows]
+    except Exception as e:
+        print(f"이미지 검색 실패: {e}")
+        return []
+
 
 def sql_search_node(state: Dict[str, Any]) -> Dict[str, Any]:
     """
     Input:
-      - state['verified_chunks']: List[Dict] (eval에서 검증된 근거)
+      - state['verified_chunks']: List[Dict] (eval에서 검증된 chunk)
     Output:
-      - state['sql_results']: List[Dict] (SQL 보강 결과)
-      - (선택) state['verified_chunks']에 append 병합
+      - state['related_images']: List[Dict] (관련 이미지 메타데이터)
     """
-    keywords = _extract_keywords(state)
-    if not psycopg:
-        # DB 드라이버 없으면 소프트 실패
-        state["sql_results"] = []
-        state["sql_error"] = "psycopg not installed"
+    if not psycopg2:
+        state["related_images"] = []
+        state["sql_error"] = "psycopg2 not installed"
         return state
-
+    
+    # chunk_id 추출
+    chunk_ids = _extract_chunk_ids(state)
+    
+    if not chunk_ids:
+        state["related_images"] = []
+        return state
+    
+    # DB 연결
+    conn = _get_db_connection()
+    if not conn:
+        state["related_images"] = []
+        state["sql_error"] = "DB connection failed"
+        return state
+    
     try:
-        conn = _connect()
-        if conn is None:
-            state["sql_results"] = []
-            state["sql_error"] = "DB connection failed"
-            return state
-        with conn, conn.cursor() as cur:
-            results = _search_sql(cur, keywords)
-    except Exception as e:
-        state["sql_results"] = []
-        state["sql_error"] = f"sql_search error: {e}"
-        return state
-
-    # 보강: verified_chunks 뒤에 붙이거나 별도 키로 전달
-    state["sql_results"] = results
-    # 선택적으로 병합하려면 아래 주석 해제
-    # state["verified_chunks"] = (state.get("verified_chunks") or []) + results
+        # 이미지 검색
+        related_images = _search_images_from_db(conn, chunk_ids)
+        state["related_images"] = related_images
+    finally:
+        conn.close()
+    
     return state


### PR DESCRIPTION
services/etl/loader/load_rdb.py로 services/etl/loader/schemas.sql 쿼리문 실행하면 생성되는 RDB테이블을 sqlnode에서 사용하도록 설정.

->현재수정PR

DJango 시스템(config/setting.py)에서 env를 로드하여 LangGraph 노드와 에이전트에서 사용하는 AImodel들이 env를 사용할 수 있도록 구현함

sql_search, classify, chat_llm 3개의 노드와 classify agent 또한 gitignore 의 복잡한 주석과 필요없는부분들 정리

->이전수정PR