### PR TITLE
eval_node 점수체계 변경 & eval_agent 수정

### DIFF
--- a/rag/graph/agents/eval_agent.py
+++ b/rag/graph/agents/eval_agent.py
@@ -17,7 +17,6 @@ eval에서 verified_chunks를 두 방향으로 동시 전달:
 
 2. verified_chunks 있음 (1개 이상)
 → sql_search 노드 (조건부 엣지)
-
 → 메타데이터로 RDB에서 관련 이미지 검색
 동시에 eval → chat_llm (직접 엣지)
 → 검증된 chunk 직접 전달
@@ -25,9 +24,11 @@ eval에서 verified_chunks를 두 방향으로 동시 전달:
 [최종 결과]
 chat_llm은 verified_chunks와 related_images 둘 다 받아서 답변 생성
 
-[임계값]
-- score >= 0.7: 관련성 높은 chunk (통과)
-- score < 0.7: 관련성 낮음 (제외)
+[점수 정책]
+- eval_node에서 chunk별로 다음 두 점수를 계산:
+  - question_relevance (0.0 ~ 0.3)
+  - answer_helpfulness (0.0 ~ 0.3)
+- 두 점수의 합(total_score)을 기준으로 임계값(THRESHOLD) 이상인 것만 verified_chunks에 포함.
 """
 
 from typing import Dict, Any, List
@@ -49,7 +50,7 @@ def eval_agent(state: Dict[str, Any]) -> Dict[str, Any]:
     return eval_node(state)
 
 
-def route_after_eval(state):
+def route_after_eval(state: Dict[str, Any]) -> str:
     """
     라우팅 함수
     
@@ -57,29 +58,11 @@ def route_after_eval(state):
         "__end__": chunk 없음 (답변 불가)
         "sql_search": chunk 있음 + 이미지 검색 필요
         "chat_llm": chunk 있음 + 이미지 검색 불필요 (바로 답변)
-        
-    Note: 
-        - 검증된 chunk가 존재하면:
-          * chunk_id가 있으면 → sql_search (이미지 검색)
-          * chunk_id가 없으면 → chat_llm (바로 답변)
-        - sql_search를 거치면 자동으로 chat_llm으로 이동
     """
     verified_chunks: List[Dict[str, Any]] = state.get("verified_chunks") or []
-    
+
     if not verified_chunks:
-        # 검증된 chunk 없음 → 답변 불가 → 종료
         return "__end__"
-    
-    # chunk_id가 있는지 확인 (이미지 검색 가능 여부)
-    has_chunk_id = any(
-        chunk.get("chunk_id") or chunk.get("metadata", {}).get("chunk_id")
-        for chunk in verified_chunks
-    )
-    
-    if has_chunk_id:
-        # chunk_id 있음 → 이미지 검색 후 답변
-        return "sql_search"
     else:
-        # chunk_id 없음 → 바로 답변
-        return "chat_llm"
+        return "sql_search"
         

--- a/rag/graph/nodes/eval_node.py
+++ b/rag/graph/nodes/eval_node.py
@@ -4,14 +4,13 @@ Eval Node
 
 [기능 설명]
 - 사용자 질문(user_question)과 검색된 chunk(retrieved_chunks)의 유사도를 LLM으로 검증하는 노드
-- gpt-5-mini 모델을 사용해 각 chunk의 관련도를 0~1 사이 점수로 평가
-- 임계값(threshold)을 기준으로 관련성이 높은 chunk만 필터링
+- 각 chunk에 대해 다음 두 기준으로 0점부터 점수를 부여:
+  1) 질문과의 관련성 (question_relevance, 0.0 ~ 0.3)
+  2) 답변에 도움이 되는 정도 (answer_helpfulness, 0.0 ~ 0.3)
+- 두 점수의 합(total_score = relevance + helpfulness)을 기준으로 필터링
 - 필터링된 chunk를 verified_chunks로 반환
 
 [입력 State]
-- user_question: str - 사용자 질문
-- retrieved_chunks: list[dict] - 검색된 chunk 리스트
-
 - user_question: str - 사용자 질문
 - retrieved_chunks: list[dict] - 검색된 chunk 리스트
     * chunk 예시:
@@ -23,10 +22,12 @@ Eval Node
 
 [출력 State]
 - user_question: str - 사용자 질문 (전달)
-- verified_chunks: list[dict] - 검증된 chunk 리스트(score >= threshold 인 것만)
+- verified_chunks: list[dict] - 검증된 chunk 리스트
   - content: str - chunk 내용
   - metadata: dict - chunk 메타데이터
-  - score: float - LLM이 판단한 유사도 점수 (0~1)
+  - score: float - 총점 (0.0 ~ 0.6)
+  - question_relevance: float - 관련성 점수 (0.0 ~ 0.3)
+  - answer_helpfulness: float - 도움됨 점수 (0.0 ~ 0.3)
 """
 
 from typing import Dict, Any, List
@@ -39,14 +40,23 @@ try:
 except Exception:
     _client = None
 
+# 점수 범위 및 임계값
+MAX_RELEVANCE = 0.3
+MAX_HELPFULNESS = 0.3
+# 임계값: 나중에 실험하면서 조정 (지금은 낮게 두고 검증용)
+THRESHOLD = 0.1
 
-def _build_chunk_preview(chunks: List[Dict[str, Any]], max_chunks: int = 10, max_chars: int = 400) -> str:
+def _build_chunk_preview(
+    chunks: List[Dict[str, Any]],
+    max_chunks: int = 10,
+    max_chars: int = 400,
+) -> str:
     """
     LLM 프롬프트에 넣기 좋은 형태로 chunk들을 정리
     - 최대 max_chunks개만 사용
     - 각 chunk는 max_chars 글자까지만 사용
     """
-    lines = []
+    lines: List[str] = []
     for i, ch in enumerate(chunks[:max_chunks]):
         content = (ch.get("content") or "").replace("\n", " ").strip()
         if len(content) > max_chars:
@@ -55,10 +65,21 @@ def _build_chunk_preview(chunks: List[Dict[str, Any]], max_chunks: int = 10, max
     return "\n".join(lines)
 
 
-def _llm_score_chunks(user_question: str, retrieved_chunks: List[Dict[str, Any]]) -> Dict[int, float]:
+def _llm_score_chunks(
+    user_question: str,
+    retrieved_chunks: List[Dict[str, Any]],
+) -> Dict[int, Dict[str, float]]:
     """
-    gpt-5-mini를 사용해 각 chunk의 관련도 점수를 0~1 사이 float로 받는 함수
-    반환값: { index: relevance_score }
+    gpt-5-mini를 사용하여 각 chunk별로 두 가지 점수를 계산:
+      - question_relevance: 0.0 ~ 0.3
+      - answer_helpfulness: 0.0 ~ 0.3
+
+    반환값 예시:
+      {
+        0: {"question_relevance": 0.25, "answer_helpfulness": 0.3},
+        1: {"question_relevance": 0.0,  "answer_helpfulness": 0.05},
+        ...
+      }
     """
     if _client is None or not retrieved_chunks or not user_question.strip():
         return {}
@@ -66,26 +87,34 @@ def _llm_score_chunks(user_question: str, retrieved_chunks: List[Dict[str, Any]]
     chunks_text = _build_chunk_preview(retrieved_chunks)
 
     system_msg = (
-        "당신은 의료/정신건강 텍스트 검색 시스템의 '관련도 평가자'입니다.\n"
-        "입력으로 사용자 질문과 여러 개의 후보 문단(chunk)이 주어집니다.\n\n"
-        "각 chunk가 질문에 얼마나 관련이 있는지 0.0~1.0 사이의 실수 점수로 평가하세요.\n"
-        "- 0.0에 가까울수록 거의 관련 없음\n"
-        "- 1.0에 가까울수록 매우 관련 있음\n\n"
-        "출력 형식은 반드시 JSON만 사용하세요. 예:\n"
+        "당신은 의료/정신건강 RAG 시스템에서 검색된 문단(chunk)의 품질을 평가하는 전문가입니다.\n"
+        "각 chunk에 대해 아래 두 기준을 독립적으로 평가하세요.\n\n"
+        "1) 질문과의 관련성(question_relevance):\n"
+        "   - 이 chunk의 내용이 사용자 질문의 주제/맥락과 얼마나 관련이 있는지 평가합니다.\n"
+        "   - 0.0 ~ 0.3 범위에서 점수를 부여하세요.\n"
+        "   - 전혀 관련 없으면 0.0, 매우 관련 있으면 0.3에 가깝게.\n\n"
+        "2) 답변에 도움이 되는 정도(answer_helpfulness):\n"
+        "   - 이 chunk가 실제로 사용자에게 제공할 답변 내용을 채우는 데 얼마나 도움이 되는지 평가합니다.\n"
+        "   - 0.0 ~ 0.3 범위에서 점수를 부여하세요.\n"
+        "   - 내용이 구체적이고 설명/정의/지침을 잘 포함할수록 높은 점수.\n\n"
+        "각 chunk에 대해 두 점수를 모두 제공하고, JSON 형식으로만 출력하세요.\n"
+        "점수는 반드시 숫자(float)이며, 범위를 벗어나지 않도록 하세요.\n\n"
+        "출력 형식(예시):\n"
         "{\n"
-        '  "results": [\n'
-        '    {"index": 0, "relevance": 0.92},\n'
-        '    {"index": 1, "relevance": 0.10}\n'
+        '  \"results\": [\n'
+        '    {\"index\": 0, \"question_relevance\": 0.25, \"answer_helpfulness\": 0.30},\n'
+        '    {\"index\": 1, \"question_relevance\": 0.10, \"answer_helpfulness\": 0.05}\n'
         "  ]\n"
-        "}\n"
-        "추가 설명, 자연어 문장, 코드 블록(````), 주석 등은 절대 넣지 마세요."
+        "}\n\n"
+        "중요:\n"
+        "- JSON 이외의 텍스트, 설명, 코드블록(````), 주석 등을 절대 출력하지 마세요."
     )
 
     user_msg = (
         f"[사용자 질문]\n{user_question}\n\n"
         "[후보 chunk 목록]\n"
         f"{chunks_text}\n\n"
-        "위 chunk들 각각에 대해 관련도 점수를 평가해주세요."
+        "각 chunk에 대해 두 점수를 평가하고 위에서 지정한 JSON 형식으로만 응답하세요."
     )
 
     try:
@@ -94,23 +123,39 @@ def _llm_score_chunks(user_question: str, retrieved_chunks: List[Dict[str, Any]]
             messages=[
                 {"role": "system", "content": system_msg},
                 {"role": "user", "content": user_msg},
-            ]
+            ],
+            # gpt-5-mini는 temperature=0.0 지원 안 함 → 기본값 사용
         )
         raw = resp.choices[0].message.content.strip()
+        print("\n[DEBUG] Raw LLM Output =======================")
+        print(raw)
+        print("==============================================\n")
+
         data = json.loads(raw)
 
         results = data.get("results", [])
-        index_to_score: Dict[int, float] = {}
+        index_to_scores: Dict[int, Dict[str, float]] = {}
+
         for item in results:
             try:
                 idx = int(item.get("index"))
-                score = float(item.get("relevance"))
-                if 0.0 <= score <= 1.0 and 0 <= idx < len(retrieved_chunks):
-                    index_to_score[idx] = score
+                q_rel = float(item.get("question_relevance", 0.0))
+                a_help = float(item.get("answer_helpfulness", 0.0))
+
+                # 범위 클램핑
+                q_rel = max(0.0, min(MAX_RELEVANCE, q_rel))
+                a_help = max(0.0, min(MAX_HELPFULNESS, a_help))
+
+                if 0 <= idx < len(retrieved_chunks):
+                    index_to_scores[idx] = {
+                        "question_relevance": q_rel,
+                        "answer_helpfulness": a_help,
+                    }
             except Exception:
+                # 잘못된 형식은 스킵
                 continue
 
-        return index_to_score
+        return index_to_scores
 
     except Exception as e:
         # LLM 오류 시 콘솔 로그 남기고 빈 dict 반환 → 폴백 로직 사용
@@ -120,44 +165,45 @@ def _llm_score_chunks(user_question: str, retrieved_chunks: List[Dict[str, Any]]
 
 def eval_node(state: Dict[str, Any]) -> Dict[str, Any]:
     """
-    검색된 chunk의 관련성을 LLM으로 검증하는 노드
+    검색된 chunk들의 관련성과 유용성을 LLM으로 평가하여 유효한 chunk만 필터링.
     """
     user_question = state.get("user_question", "")
-    retrieved_chunks = state.get("retrieved_chunks", []) or []
+    retrieved_chunks: List[Dict[str, Any]] = state.get("retrieved_chunks", []) or []
 
     # 아무 것도 없으면 바로 반환
-    if not retrieved_chunks or not user_question.strip():
+    if not user_question.strip() or not retrieved_chunks:
         return {
             "user_question": user_question,
             "verified_chunks": []
         }
 
-    # TODO: 임계값 기반 chunk 필터링
-
-    # 기본 임계값
-    threshold = 0.7
-
-    # 1) LLM으로 관련도 점수 받기
-    index_to_score = _llm_score_chunks(user_question, retrieved_chunks)
+    # 1) LLM으로 세부 점수 계산
+    scored = _llm_score_chunks(user_question, retrieved_chunks)
 
     verified_chunks: List[Dict[str, Any]] = []
 
-    if index_to_score:
-        # LLM 점수가 있으면 그 점수를 기준으로 필터링
+    if scored:
+        # LLM 점수를 사용하여 total_score 계산 후 필터링
         for idx, chunk in enumerate(retrieved_chunks):
-            score = index_to_score.get(idx)
-            if score is None:
+            scores = scored.get(idx)
+            if not scores:
                 continue
-            if score >= threshold:
-                # chunk에 LLM 점수를 덮어써서 downstream에서 활용 가능하도록
+
+            q_rel = float(scores.get("question_relevance", 0.0))
+            a_help = float(scores.get("answer_helpfulness", 0.0))
+            total = q_rel + a_help  # 0.0 ~ 0.6
+
+            if total >= THRESHOLD:
                 new_chunk = dict(chunk)
-                new_chunk["score"] = float(score)
+                new_chunk["question_relevance"] = q_rel
+                new_chunk["answer_helpfulness"] = a_help
+                new_chunk["score"] = total  # downstream에서 사용할 총점
                 verified_chunks.append(new_chunk)
     else:
-        # 2) LLM 사용이 불가능하거나 실패한 경우, 기존 score 기반 필터링으로 폴백
+        # 2) LLM 사용 불가/실패 시: 기존 score 값이 있다면 동일 threshold로 폴백
         verified_chunks = [
             chunk for chunk in retrieved_chunks
-            if float(chunk.get("score", 0)) >= threshold
+            if float(chunk.get("score", 0.0)) >= THRESHOLD
         ]
 
     return {

--- a/rag/test_eval_agent.py
+++ b/rag/test_eval_agent.py
@@ -1,0 +1,17 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+from rag.graph.agents.eval_agent import eval_agent, route_after_eval
+
+state = {
+    "user_question": "불안장애가 있으면 어떤 증상들이 나타나나요?",
+    "retrieved_chunks": [
+        {"content": "불안장애는 지속적인 불안과 긴장감을 특징으로 합니다.", "metadata": {"doc_id": 1}},
+    ]
+}
+
+after_eval = eval_agent(state)
+print("[after_eval]", after_eval)
+
+route = route_after_eval(after_eval)
+print("[route]", route)

--- a/rag/test_eval_node.py
+++ b/rag/test_eval_node.py
@@ -1,0 +1,47 @@
+# rag/test_eval_node.py
+
+"""
+eval_node.py 단위 테스트 파일
+
+목적:
+- LLM이 chunk별로 question_relevance / answer_helpfulness 점수를 잘 생성하는지 확인
+- total_score = relevance + helpfulness 계산 및 THRESHOLD 필터링 검증
+- verified_chunks에 필터링된 chunk가 잘 들어오는지 체크
+"""
+
+from dotenv import load_dotenv
+load_dotenv()  # 루트의 .env에서 OPENAI_API_KEY 읽기
+
+from rag.graph.nodes.eval_node import eval_node
+
+
+def main():
+    test_state = {
+        "user_question": "불안장애가 있으면 어떤 증상들이 나타나나요?",
+        "retrieved_chunks": [
+            {
+                "content": "불안장애는 지속적인 불안과 긴장감을 특징으로 합니다.",
+                "metadata": {"doc_id": 1},
+            },
+            {
+                "content": "ADHD는 주의력 결핍과 과잉 행동을 보이는 신경발달장애입니다.",
+                "metadata": {"doc_id": 2},
+            },
+            {
+                "content": "불안장애 치료는 약물치료와 인지행동치료가 있습니다.",
+                "metadata": {"doc_id": 3},
+            },
+        ],
+    }
+
+    print("\n===== eval_node TEST START =====")
+    result = eval_node(test_state)
+
+    print("\n----- 최종 결과 (verified_chunks) -----")
+    print(result)
+
+    print("\n===== eval_node TEST END =====\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/test_eval_node.py
+++ b/rag/test_eval_node.py
@@ -1,46 +1,65 @@
-# rag/test_eval_node.py
-
 """
 eval_node.py 단위 테스트 파일
 
+- eval_node + search_vectordb_node 연동 단위 테스트
+
 목적:
-- LLM이 chunk별로 question_relevance / answer_helpfulness 점수를 잘 생성하는지 확인
-- total_score = relevance + helpfulness 계산 및 THRESHOLD 필터링 검증
-- verified_chunks에 필터링된 chunk가 잘 들어오는지 체크
+- search_vectordb_node를 통해 실제 VectorDB에서 retrieved_chunks를 가져오고
+- 해당 청크들을 eval_node에 넣어 LLM 기반 점수/필터링이 정상 동작하는지 확인
 """
 
 from dotenv import load_dotenv
-load_dotenv()  # 루트의 .env에서 OPENAI_API_KEY 읽기
+load_dotenv()  # .env에서 OPENAI_API_KEY 읽기
 
+from rag.graph.nodes.search_vectordb_node import search_vectordb_node
 from rag.graph.nodes.eval_node import eval_node
 
 
 def main():
-    test_state = {
-        "user_question": "불안장애가 있으면 어떤 증상들이 나타나나요?",
-        "retrieved_chunks": [
-            {
-                "content": "불안장애는 지속적인 불안과 긴장감을 특징으로 합니다.",
-                "metadata": {"doc_id": 1},
-            },
-            {
-                "content": "ADHD는 주의력 결핍과 과잉 행동을 보이는 신경발달장애입니다.",
-                "metadata": {"doc_id": 2},
-            },
-            {
-                "content": "불안장애 치료는 약물치료와 인지행동치료가 있습니다.",
-                "metadata": {"doc_id": 3},
-            },
-        ],
+    # 테스트용 사용자 질문 (필요하면 이 문장은 바꿔가며 여러 번 실험)
+    user_question = "불안장애가 있으면 어떤 증상들이 나타나나요?"
+
+    # 1) 초기 state: 질문 + question_type만 넣고 시작
+    state = {
+        "user_question": user_question,
+        "question_type": "information",
     }
 
-    print("\n===== eval_node TEST START =====")
-    result = eval_node(test_state)
+    print("\n===== search_vectordb_node TEST START =====")
+    after_search = search_vectordb_node(state)
 
-    print("\n----- 최종 결과 (verified_chunks) -----")
-    print(result)
+    retrieved_chunks = after_search.get("retrieved_chunks") or []
+    print(f"[search_vectordb_node] retrieved_chunks count = {len(retrieved_chunks)}")
 
-    print("\n===== eval_node TEST END =====\n")
+    # 필요하면 어떤 청크가 왔는지 간단히 내용 확인
+    for i, ch in enumerate(retrieved_chunks[:3]):  # 상위 3개만 preview
+        preview = (ch.get("content") or "").replace("\n", " ")
+        if len(preview) > 120:
+            preview = preview[:117] + "..."
+        print(f"  - chunk[{i}] preview: {preview}")
+
+    print("===== search_vectordb_node TEST END =====\n")
+
+    print("===== eval_node TEST START =====")
+    after_eval = eval_node(after_search)
+
+    verified_chunks = after_eval.get("verified_chunks") or []
+    print(f"[eval_node] verified_chunks count = {len(verified_chunks)}")
+
+    # 점수와 함께 상위 몇 개만 출력
+    for i, ch in enumerate(verified_chunks[:5]):
+        q_rel = ch.get("question_relevance")
+        a_help = ch.get("answer_helpfulness")
+        score = ch.get("score")
+        preview = (ch.get("content") or "").replace("\n", " ")
+        if len(preview) > 120:
+            preview = preview[:117] + "..."
+        print(
+            f"  - verified[{i}] score={score:.3f} "
+            f"(rel={q_rel:.3f}, help={a_help:.3f}) :: {preview}"
+        )
+
+    print("===== eval_node TEST END =====\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1) eval_node 점수 체계 개선 
  - 기존 단일 score 필터링을 제거하고 LLM 평가 기반 2단계 점수 체계로 변경 
    - 관련성(question_relevance, 0~0.3)
    - 답변 기여도(answer_helpfulness, 0~0.3) 
  - 두 점수의 합(total_score, 0~0.6)을 기준으로 청크 필터링하도록 반영 
  
2) eval_agent 정상동작 확인
  - eval_node 결과(verified_chunks)를 정상적으로 반영하도록 유지·정리 
  - verified_chunks 유무에 따라 __end__ / sql_search 라우팅 정상 동작 확인 
  
3) rag/test_eval_node.py / rag/test_eval_agent.py로 단위 테스트 수행 

4) Threshold 추천 범위 
  - 단위 테스트에서 확인된 score 분포 기준: 
     - 핵심 관련 청크: 0.45 ~ 0.60 
     - 준관련(보조적) 청크: 0.15 ~ 0.25 
     - 무관 청크: 0.0 
  - 추천 범위: 
     - 최소 통과 기준: 0.15 
     - 안정적 기준: 0.20 ~ 0.30 
     - 엄격 기준: 0.35 이상 
  - 현재 기본값은 실험을 위해 THRESHOLD = 0.1로 설정해둠 
  - 실제 운영 시 0.2~0.3 사이로 조정